### PR TITLE
Disable line-length checking in flake8 and pylint

### DIFF
--- a/{{cookiecutter.project_slug}}/.flake8
+++ b/{{cookiecutter.project_slug}}/.flake8
@@ -19,4 +19,4 @@ ignore =
     E402
     # already covered by PyLint and gives false positives for typing.overload
     F811
-max-line-length = 100
+max-line-length = 300

--- a/{{cookiecutter.project_slug}}/.flake8
+++ b/{{cookiecutter.project_slug}}/.flake8
@@ -19,4 +19,5 @@ ignore =
     E402
     # already covered by PyLint and gives false positives for typing.overload
     F811
+# Large value is used here as we use black to handle line length
 max-line-length = 300

--- a/{{cookiecutter.project_slug}}/.pylintrc
+++ b/{{cookiecutter.project_slug}}/.pylintrc
@@ -198,6 +198,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
+# (Large value is used here as we use black to handle line length)
 max-line-length=300
 
 # Maximum number of lines in a module

--- a/{{cookiecutter.project_slug}}/.pylintrc
+++ b/{{cookiecutter.project_slug}}/.pylintrc
@@ -198,7 +198,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=300
 
 # Maximum number of lines in a module
 max-module-lines=1000


### PR DESCRIPTION
Closes #14 
Done by increasing line lenngth limit to 300.
